### PR TITLE
必修登録時に全曜限初期化

### DIFF
--- a/classList/script.js
+++ b/classList/script.js
@@ -324,6 +324,14 @@ async function registerHisshu(classId) {
   registeredLecturesList = [];
   registeredLecturesListForCredit = [];
 
+    // カレンダーの全曜限を更新する
+    for (const day in weekNameEnToJp) {
+      for (let num = 1; num <= 6; num++) {
+        const cell = new CalenderCell(day, num.toString());
+        cell.writeInCalender();
+      }
+    }
+
   if (isValidClassId) {
     const requiredLectureCodeList = (await firstHisshuDB)[classId];
     for (const lecture of (await allLectureDB).filter(


### PR DESCRIPTION
必修登録前に初期化。これにより、文一12組登録後に理一12組を登録して初ゼミ文科が残るようなことはなくなった。